### PR TITLE
.jd2r_finitefilters() fix

### DIFF
--- a/R/2_finite_filters.R
+++ b/R/2_finite_filters.R
@@ -83,7 +83,7 @@ finite_filters.matrix <- function(sfilter,
 
 
 #' @export
-.jd2r_finitefilters <- function(jf, first_to_last = TRUE){
+.jd2r_finitefilters <- function(jf, first_to_last){
     jf<-.jcast(jf, "jdplus.toolkit.base.core.math.linearfilters/IFiltering")
     if (! is.jnull(jf)) {
       jsfilter <- .jcall(jf, "Ljdplus/toolkit/base/core/math/linearfilters/IFiniteFilter;", "centralFilter")
@@ -93,6 +93,24 @@ finite_filters.matrix <- function(sfilter,
       sfilter = .jd2ma(jsfilter)
       rfilters = lapply(jrfilter, .jd2ma)
       lfilters = rev(lapply(jlfilter, .jd2ma))
+
+      if (missing(first_to_last)) {
+        if (all(diff(sapply(lfilters, length)) <= 0)) {
+          lfilters <- rev(lfilters)
+          rfilters <- rev(rfilters)
+        }
+      } else {
+        if(first_to_last) {
+          lfilters <- rev(lfilters)
+          rfilters <- rev(rfilters)
+        }
+      }
+
+      finite_filters(sfilter = sfilter,
+                     rfilters = rfilters,
+                     lfilters = lfilters)
+    } else {
+      NULL
     }
 #  if (.jinstanceof(jf, "jdplus/x12plus/base/core/X11SeasonalFiltersFactory$AnyFilter")) {
 #    jsfilter <- .jcall(jf, "Ljdplus/toolkit/base/core/math/linearfilters/SymmetricFilter;", "symmetricFilter")
@@ -123,9 +141,6 @@ finite_filters.matrix <- function(sfilter,
 #    lfilters <- NULL
 #  }
 
-  finite_filters(sfilter = sfilter,
-                 rfilters = rfilters,
-                 lfilters = lfilters)
 }
 #' @rdname filters_operations
 #' @export

--- a/R/RKHS.R
+++ b/R/RKHS.R
@@ -148,8 +148,8 @@ rkhs_optimal_bw <- function(horizon = 6,  degree = 2,
 rkhs_kernel <- function(kernel = c("Biweight", "Henderson", "Epanechnikov", "Triangular", "Uniform", "Triweight"),
                         degree = 2, horizon = 6){
   kernel <- match.arg(tolower(kernel)[1],
-                      choices = c("biweight", "henderson", "epanechnikov", "triangular", "uniform",
-                                  "triweight"))
+                   choices = c("biweight", "henderson", "epanechnikov", "triangular", "uniform",
+                               "triweight"))
   kernel =  switch(tolower(kernel),
     "biweight" = "BiWeight",
     "triweight" ="TriWeight",

--- a/R/RKHS.R
+++ b/R/RKHS.R
@@ -29,8 +29,26 @@ rkhs_filter <- function(horizon = 6, degree = 2,
                         optimal.minBandwidth = horizon,
                         optimal.maxBandwidth = 3*horizon,
                         bandwidth = horizon + 1){
-  kernel = match.arg(kernel)
-  asymmetricCriterion = match.arg(asymmetricCriterion)
+  kernel <- match.arg(tolower(kernel)[1],
+                   choices = c("biweight", "henderson", "epanechnikov", "triangular", "uniform",
+                               "triweight"))
+  # In next release of Java files, remove next lines
+  kernel = switch(tolower(kernel),
+                  "biweight" = "BiWeight",
+                  "triweight" ="TriWeight",
+                  "uniform" = "Uniform",
+                  "triangular" = "Triangular",
+                  "epanechnikov" = "Epanechnikov",
+                  "henderson" = "Henderson"
+  )
+
+  asymmetricCriterion = switch(tolower(asymmetricCriterion[1]),
+                               timeliness = "Timeliness",
+                               frequencyresponse = "FrequencyResponse",
+                               accuracy = "Accuracy",
+                               smoothness = "Smoothness",
+                               undefined = "Undefined")
+
   density = match.arg(density)
 
   jrkhs_filter =
@@ -73,8 +91,15 @@ rkhs_optimization_fun <- function(horizon = 6, leads = 0,  degree = 2,
                         asymmetricCriterion = c("Timeliness", "FrequencyResponse", "Accuracy", "Smoothness"),
                         density = c("uniform", "rw"),
                         passband = 2*pi/12){
-  kernel = match.arg(kernel)
-  asymmetricCriterion = match.arg(asymmetricCriterion)
+  kernel <- match.arg(tolower(kernel)[1],
+                   choices = c("biweight", "henderson", "epanechnikov", "triangular", "uniform",
+                               "triweight"))
+  asymmetricCriterion = switch(tolower(asymmetricCriterion[1]),
+                               timeliness = "Timeliness",
+                               frequencyresponse = "FrequencyResponse",
+                               accuracy = "Accuracy",
+                               smoothness = "Smoothness",
+                               undefined = "Undefined")
   density = match.arg(density)
   optimalFunCriteria = J("jdplus/filters/base/r/RKHSFilters")$optimalCriteria(
     as.integer(horizon), as.integer(leads), as.integer(degree), kernel,
@@ -100,8 +125,15 @@ rkhs_optimal_bw <- function(horizon = 6,  degree = 2,
                            passband = 2*pi/12,
                            optimal.minBandwidth = horizon,
                            optimal.maxBandwidth = 3*horizon){
-  kernel = match.arg(kernel)
-  asymmetricCriterion = match.arg(asymmetricCriterion)
+  kernel <- match.arg(tolower(kernel)[1],
+                      choices = c("biweight", "henderson", "epanechnikov", "triangular", "uniform",
+                                  "triweight"))
+  asymmetricCriterion = switch(tolower(asymmetricCriterion[1]),
+                               timeliness = "Timeliness",
+                               frequencyresponse = "FrequencyResponse",
+                               accuracy = "Accuracy",
+                               smoothness = "Smoothness",
+                               undefined = "Undefined")
   density = match.arg(density)
   optimalBw= J("jdplus/filters/base/r/RKHSFilters")$optimalBandwidth(
     as.integer(horizon), as.integer(degree), kernel,
@@ -115,7 +147,9 @@ rkhs_optimal_bw <- function(horizon = 6,  degree = 2,
 #' @export
 rkhs_kernel <- function(kernel = c("Biweight", "Henderson", "Epanechnikov", "Triangular", "Uniform", "Triweight"),
                         degree = 2, horizon = 6){
-  kernel = match.arg(kernel)
+  kernel <- match.arg(tolower(kernel)[1],
+                      choices = c("biweight", "henderson", "epanechnikov", "triangular", "uniform",
+                                  "triweight"))
   kernel =  switch(tolower(kernel),
     "biweight" = "BiWeight",
     "triweight" ="TriWeight",

--- a/R/kernels.R
+++ b/R/kernels.R
@@ -12,15 +12,18 @@
 #' @examples
 #' get_kernel("Henderson", horizon = 3)
 get_kernel <- function(kernel = c("Henderson","Uniform", "Triangular",
-                                  "Epanechnikov","Parabolic","Biweight", "Triweight","Tricube",
+                                  "Epanechnikov","Parabolic","BiWeight", "TriWeight","Tricube",
                                   "Trapezoidal", "Gaussian"),
                        horizon,
                        sd_gauss = 0.25){
-  kernel = match.arg(kernel)
-  if(kernel == "Parabolic")
-    kernel = "Epanechnikov"
+  kernel = match.arg(tolower(kernel)[1],
+                     choices = c("henderson", "uniform", "triangular", "epanechnikov", "parabolic",
+                                 "biweight", "triweight", "tricube", "trapezoidal", "gaussian"
+                     ))
+  if(kernel == "parabolic")
+    kernel = "epanechnikov"
   h <- as.integer(horizon)
-  if(kernel == "Gaussian"){
+  if(kernel == "gaussian"){
     jkernel <- .jcall("jdplus/toolkit/base/core/data/analysis/DiscreteKernel",
                       "Ljava/util/function/IntToDoubleFunction;",
                       tolower(kernel), h, sd_gauss)

--- a/R/lp_filters.R
+++ b/R/lp_filters.R
@@ -32,7 +32,9 @@ localpolynomials<-function(x,
     stop("You need more observation (2 * horizon + 1) than variables (degree + 1) to estimate the filter.")
 
   d<-2/(sqrt(pi)*ic)
-  kernel=match.arg(kernel)
+  kernel=match.arg(tolower(kernel),
+                   choices = c("henderson", "uniform", "biweight", "trapezoidal", "triweight",
+                               "tricube", "gaussian", "triangular", "parabolic"))
   endpoints=match.arg(endpoints)
   result <- .jcall("jdplus/filters/base/r/LocalPolynomialFilters", "[D", "filter",
                    as.numeric(x), as.integer(horizon), as.integer(degree), kernel, endpoints, d,
@@ -75,7 +77,9 @@ lp_filter <- function(horizon = 6, degree = 3,
   if(2*horizon < degree)
     stop("You need more observation (2 * horizon + 1) than variables (degree + 1) to estimate the filter.")
   d<-2/(sqrt(pi)*ic)
-  kernel=match.arg(kernel)
+  kernel=match.arg(tolower(kernel),
+                   choices = c("henderson", "uniform", "biweight", "trapezoidal", "triweight",
+                               "tricube", "gaussian", "triangular", "parabolic"))
   endpoints=match.arg(endpoints)
   jprops<-.jcall("jdplus/filters/base/r/LocalPolynomialFilters",
                  "Ljdplus/toolkit/base/core/math/linearfilters/ISymmetricFiltering;",

--- a/R/lp_filters.R
+++ b/R/lp_filters.R
@@ -83,7 +83,7 @@ lp_filter <- function(horizon = 6, degree = 3,
                  as.integer(degree), kernel, endpoints, d,
                  tweight, passband)
 
-  return(.jd2r_finitefilters(jprops, first_to_last = FALSE))
+  return(.jd2r_finitefilters(jprops))
 }
 coefficients_names <- function(lb, ub){
   x <- sprintf("t%+i", seq(lb,ub))

--- a/README.Rmd
+++ b/README.Rmd
@@ -43,7 +43,6 @@ To get the current development version from GitHub:
 
 ```{r, eval = FALSE}
 # install.packages("remotes")
-=======
 # Install development version from GitHub
 remotes::install_github("rjdemetra/rjd3toolkit")
 remotes::install_github("rjdemetra/rjd3filters")

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ To get the current development version from GitHub:
 
 ``` r
 # install.packages("remotes")
-=======
 # Install development version from GitHub
 remotes::install_github("rjdemetra/rjd3toolkit")
 remotes::install_github("rjdemetra/rjd3filters")

--- a/man/get_kernel.Rd
+++ b/man/get_kernel.Rd
@@ -6,7 +6,7 @@
 \usage{
 get_kernel(
   kernel = c("Henderson", "Uniform", "Triangular", "Epanechnikov", "Parabolic",
-    "Biweight", "Triweight", "Tricube", "Trapezoidal", "Gaussian"),
+    "BiWeight", "TriWeight", "Tricube", "Trapezoidal", "Gaussian"),
   horizon,
   sd_gauss = 0.25
 )


### PR DESCRIPTION
- fix `.jd2r_finitefilters()` to manage the exxor with DAF/CN link to Java code (see https://github.com/jdemetra/jdplus-incubator/pull/91)
- README correction