### PR TITLE
parameter asymmetric_var to confint_filter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * New function `mmsre_filter()` to compute the general Proietti and Luati (2008) filter with extension for non symmetric filters and with Timeliness criterion.
 
+* New parameter to `confint_filter()` to specify if the variance should be estimated for each asymmetric filters (default) instead of using the variance associated the symmetric estimates.
+
+
 ### Changed
 
 * `filter()` correction when the length of the series equals the length of the filter.
@@ -30,7 +33,6 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 * New functions to compute functions to compute diagnostics and goodness of fit of filtered series: cross validation (`cv()`) and cross validate estimate (`cve()`), leave-one-out cross validation estimate (`loocve`), CP statistic (`cp()`) and Rice's T statistics (`rt()`).
-
 * New function `confint_filter()` to compute confidence intervals for filtered series.
 * New function `is.finite_filters()`.
 * New parameter `zero_as_na` in `cbind.moving_average`, boolean indicating if trealing and leading zeros added to have a matrix form should be replaced by `NA`.

--- a/man/confint_filter.Rd
+++ b/man/confint_filter.Rd
@@ -9,6 +9,7 @@ confint_filter(
   coef,
   coef_var = coef,
   level = 0.95,
+  asymmetric_var = TRUE,
   gaussian_distribution = FALSE,
   exact_df = TRUE,
   ...
@@ -23,6 +24,8 @@ confint_filter(
 By default equal to \code{coef}.}
 
 \item{level}{confidence level.}
+
+\item{asymmetric_var}{if \code{asymmetric_var = TRUE} then the variance is estimated for each asymmetric filters instead of using the variance associated the symmetric estimates.}
 
 \item{gaussian_distribution}{if \code{TRUE} use the normal distribution to compute the confidence interval, otherwise use the t-distribution.}
 


### PR DESCRIPTION
* New parameter to `confint_filter()` to specify if the variance should be estimated for each asymmetric filters (default) instead of using the variance associated the symmetric estimates.